### PR TITLE
ci: add a ci job that verifies formatting of .cpp and .h source files

### DIFF
--- a/.github/workflows/verify-formatting.yml
+++ b/.github/workflows/verify-formatting.yml
@@ -1,0 +1,24 @@
+name: Verify Formatting
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  clang-format-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install clang-format
+        run: sudo apt-get update && sudo apt-get install -y clang-format
+
+      - name: Make script executable
+        run: chmod +x scripts/verify-formatting.sh
+
+      - name: Run verify-formatting.sh
+        run: ./scripts/verify-formatting.sh


### PR DESCRIPTION
Closes #6 